### PR TITLE
Update project.pbxproj for carthage

### DIFF
--- a/AsyncKit.xcodeproj/project.pbxproj
+++ b/AsyncKit.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 				TargetAttributes = {
 					6CF603151C3AB5DC00086D86 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -243,6 +244,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.mishimay.AsyncKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -260,6 +262,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.mishimay.AsyncKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
When I did `carthage update --platform iOS`, Xcode failed to build.
Because `project.pbxproj` doesn't have `SWIFT_VERSION = 3.0;`

```
/usr/bin/xcrun xcodebuild -project /Users/XXXXX/XXXX/XXXX/Carthage/Checkouts/AsyncKit/AsyncKit.xcodeproj -scheme AsyncKit -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    BITCODE_GENERATION_MODE = bitcode
    CARTHAGE = YES
    CODE_SIGN_IDENTITY =
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO
    SDKROOT = iphoneos10.0

=== CLEAN TARGET AsyncKit OF PROJECT AsyncKit WITH CONFIGURATION Release ===

Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
```
